### PR TITLE
Fix for fn_UnGarrison.sqf

### DIFF
--- a/src/addons/ares_zeusExtensions/modules/Behaviours/fn_UnGarrison.sqf
+++ b/src/addons/ares_zeusExtensions/modules/Behaviours/fn_UnGarrison.sqf
@@ -10,6 +10,7 @@ if (_activated && local _logic) then
 	// garrisoning. Choose a point outside so they try to leave the building.
 	_outsidePos = [getPos (leader _groupUnderCursor), [3,15], 2, 0] call Ares_fnc_GetSafePos;
 	{
+		_x enableAI "MOVE";
 		_x doMove _outsidePos;
 	} forEach(units _groupUnderCursor);
 


### PR DESCRIPTION
fn_ZenOccupyHouse.sqf disables move AI (line 133), so they never leave the buildings or do anything else after they have been given the garrison command.  This should allow for un-garrisoning to work correctly.
