### PR TITLE
Teleport Bipod Fix

### DIFF
--- a/src/addons/ares_zeusExtensions/functions/fn_TeleportPlayers.sqf
+++ b/src/addons/ares_zeusExtensions/functions/fn_TeleportPlayers.sqf
@@ -20,14 +20,6 @@ if (_showTeleportMessage) then
 		{
 			sleep 1;
 		};
-
-		// If the player is in a vehicle, kick them out.
-		if (vehicle _unit != _unit) then
-		{
-			_unit action ["Eject", vehicle _unit];
-		};
-
-		_smallRandomOffset = [(random 6) - 3, (random 6) - 3, 0];
-		_unit setPos (_teleportLocation vectorAdd _smallRandomOffset);
+		[_unit, _teleportLocation] call BIS_fnc_moveToRespawnPosition;
 	};
 } forEach _playersToTeleport;

--- a/src/addons/ares_zeusExtensions/functions/fn_TeleportPlayers.sqf
+++ b/src/addons/ares_zeusExtensions/functions/fn_TeleportPlayers.sqf
@@ -1,3 +1,20 @@
+/*
+ * Author: Anthon, Fisher
+ * Zeus module function to teleport players
+ *
+ * Arguments:
+ * 0: PlayersToTeleport <OBJECTS>
+ * 1: Teleport Location <ARRAY>
+ *
+ * Return Value:
+ * None <NIL>
+ *
+ * Example:
+ * [_playersToTeleport, _location] call Ares_fnc_TeleportPlayers;
+ *
+ */
+
+
 _playersToTeleport = _this select 0;
 _teleportLocation = _this select 1;
 _showTeleportMessage = [_this, 2, true, [true]] call BIS_fnc_param;
@@ -20,6 +37,14 @@ if (_showTeleportMessage) then
 		{
 			sleep 1;
 		};
+		
+		//if Unit in vehicle, kick them out
+		if (vehicle _unit != _unit) then
+		{
+			_unit action["Eject", vehicle _unit];
+		}; 
+		
+		//Teleport player using BIS_fnc_moveToRespawnPosition
 		[_unit, _teleportLocation] call BIS_fnc_moveToRespawnPosition;
 	};
 } forEach _playersToTeleport;


### PR DESCRIPTION
**Changelog:**
- Changed the setPos to BIS's function [moveToRespawnPosition](https://community.bistudio.com/wiki/BIS_fnc_moveToRespawnPosition)

This should fix the issue that a player wont be teleported when a bipod is deployed, aswell as some other issues